### PR TITLE
[Fix] cd 로직 쉘 스크립트 실행 방식으로 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,9 +26,5 @@ jobs:
           key: ${{secrets.PEM_KEY}}
           port: ${{secrets.PORT}}
           script: |
-            cd /home/ubuntu/WhereMyBus-BE/server
-            echo "${{secrets.ENV}}" > .env.prod
-            git pull origin main
-            npm ci --omit=dev -y
-            npm run build
-            pm2 reload ecosystem.config.js
+            echo "${{secrets.ENV}}" > /home/ubuntu/WhereMyBus-BE/server/.env.prod
+            bash /home/ubuntu/deploy.sh >> /dev/deploy.log 2>&1


### PR DESCRIPTION
## 작업내용
cd 로직 github action으로 ssh 접속 -> 명령어 실행 방식에서
서버에 쉘스크립트 작성 후 해당 쉘스크립트 실행으로 방식 변경
1. 여러 명령어들이 링크되어있지 않아서 실행에 오류생김
pm2, nest 명령어를 찾을 수 없다는 오류 발생함
2. cd 로직 테스트가 간편함
서버에서 쉘스크립트 실행만으로 배포테스트가 가능함

## 리뷰요청
- 

## 관련 이슈
close #32 
