### PR TITLE
[Fix] 이전 버전 support, 다음 정류장 값이 저장되지 않은 경우에도 정보를 보낼 수 있게 처리

### DIFF
--- a/server/src/regular-alarm/regular-alarm.service.ts
+++ b/server/src/regular-alarm/regular-alarm.service.ts
@@ -82,7 +82,7 @@ export class RegularAlarmService {
         .msgBody.itemList.filter(
           (each) =>
             each.busRouteId === info.busRouteId &&
-            each.adirection === info.adirection,
+            (each.adirection === null || each.adirection === info.adirection),
         );
 
       if (busInfo.length > 0) {


### PR DESCRIPTION
## 작업내용
도착정보를 필터링할때 adirection 조건을 그냥 추가하게 되면 기존에 저장된 값들은 adirection 값이 없어서 오류가 발생, 알림을 받지 못함
-> 따라서 이전 버전도 지원할 수 있게 필터링 조건 수정

## 리뷰요청
- 

## 관련 이슈
close #
