### PR TITLE
[Fix] 버스 정보 필터링 버그 수정

### DIFF
--- a/server/src/regular-alarm/regular-alarm.service.ts
+++ b/server/src/regular-alarm/regular-alarm.service.ts
@@ -78,7 +78,11 @@ export class RegularAlarmService {
     infos.forEach((info) => {
       const busInfo: Item[] = stationArrivalInfoMap
         .get(info.arsId)
-        .msgBody.itemList.filter(this.isTargetInfo);
+        .msgBody.itemList.filter(
+          (item) =>
+            item.busRouteId === info.busRouteId &&
+            (item.adirection === null || item.adirection === info.adirection),
+        );
 
       if (busInfo.length > 0) {
         const { subTitle, message } = this.getMessageContent(busInfo[0]);
@@ -155,12 +159,5 @@ export class RegularAlarmService {
     if (next) message = '다음 버스가 ' + message;
     if (info.includes('막차')) message = '[막차] ' + message;
     return message ? message : info;
-  }
-
-  isTargetInfo(item: Item): boolean {
-    return (
-      item.busRouteId === item.busRouteId &&
-      (item.adirection === null || item.adirection === item.adirection)
-    );
   }
 }


### PR DESCRIPTION
## 작업내용
regular-alarm.service.isTargetInfo 삭제 및 로직 수정

```typescript
isTargetInfo(item: Item): boolean {
  return (
    item.busRouteId === item.busRouteId &&
    (item.adirection === null || item.adirection === item.adirection)
  );
}
```
=> 항상 true를 반환하는 버그가 있었음
(어떤 버스정류장에서 버스를 등록해도... 항상 같은 버스의 정보를 받았을 것임.... 😢  )

## 리뷰요청
- 

## 관련 이슈
close #57 
